### PR TITLE
Fix division of PerlScalar

### DIFF
--- a/template/util.py
+++ b/template/util.py
@@ -311,7 +311,7 @@ class PerlScalar:
     def __mul__(self, other):
         return PerlScalar(self.__numify() * other.__numify(), self.__truth)
 
-    def __div__(self, other):
+    def __truediv__(self, other):
         return PerlScalar(self.__numify() / other.__numify(), self.__truth)
 
     def __mod__(self, other):


### PR DESCRIPTION
The division operator has to be defined by __truediv__, not by __div__